### PR TITLE
Update Dockerfile to go1.18 syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@
 # MailHog Dockerfile
 #
 
-FROM golang:alpine as builder
+FROM golang:1.18-alpine as builder
 
 # Install MailHog:
 RUN apk --no-cache add --virtual build-dependencies \
     git \
   && mkdir -p /root/gocode \
   && export GOPATH=/root/gocode \
-  && go get github.com/mailhog/MailHog
+  && go install github.com/mailhog/MailHog@latest
 
 FROM alpine:3
 # Add mailhog user/group with uid/gid 1000.


### PR DESCRIPTION
As of 1.18, `go get <package>` no longer builds executables. `go install` should be used to install an executable instead.
See the deprecation message for more information: https://go.dev/doc/go-get-install-deprecation

Pinning to a specific go Docker image will help keep things from breaking unexpectedly in the future